### PR TITLE
収支を追加するボタンを作成、画面遷移の処理を実装

### DIFF
--- a/HousekeepingBook/HousekeepingBook/Base.lproj/Main.storyboard
+++ b/HousekeepingBook/HousekeepingBook/Base.lproj/Main.storyboard
@@ -45,14 +45,14 @@
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="　" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PPs-4P-fFy">
-                                                                <rect key="frame" x="0.0" y="369.5" width="414" height="24"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PPs-4P-fFy">
+                                                                <rect key="frame" x="0.0" y="369.5" width="414" height="50"/>
                                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PSf-no-2x5">
-                                                                <rect key="frame" x="0.0" y="393.5" width="414" height="424.5"/>
+                                                                <rect key="frame" x="0.0" y="419.5" width="414" height="398.5"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                                 <prototypes>
                                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" id="Wtj-SR-ap7">

--- a/HousekeepingBook/HousekeepingBook/Base.lproj/Main.storyboard
+++ b/HousekeepingBook/HousekeepingBook/Base.lproj/Main.storyboard
@@ -84,7 +84,7 @@
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EPw-F5-02E">
                                                 <rect key="frame" x="414" y="0.0" width="414" height="818"/>
-                                                <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                                <color key="backgroundColor" systemColor="labelColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
@@ -97,13 +97,35 @@
                                     <constraint firstItem="iHV-dw-gRf" firstAttribute="height" secondItem="HGH-Wl-gSw" secondAttribute="height" id="zUJ-kE-w2A"/>
                                 </constraints>
                             </scrollView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y4Y-Mr-yWF">
+                                <rect key="frame" x="324" y="770" width="60" height="60"/>
+                                <color key="backgroundColor" systemColor="systemCyanColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="IQB-cx-Fu1"/>
+                                    <constraint firstAttribute="width" constant="60" id="RYe-vR-gGr"/>
+                                </constraints>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" image="square.and.pencil" catalog="system"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="30"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="clipsToBounds" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="XyV-Qm-Y5v" kind="presentation" id="eYi-MW-Kao"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="b3p-iK-gOa" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="771-Xu-vk0"/>
+                            <constraint firstItem="Y4Y-Mr-yWF" firstAttribute="top" secondItem="HGH-Wl-gSw" secondAttribute="bottom" constant="-92" id="Cdx-8X-Ekb"/>
                             <constraint firstItem="EPw-F5-02E" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="DVi-fb-JmV"/>
                             <constraint firstItem="HGH-Wl-gSw" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="I7E-NJ-10A"/>
+                            <constraint firstItem="Y4Y-Mr-yWF" firstAttribute="leading" secondItem="HGH-Wl-gSw" secondAttribute="trailing" constant="-90" id="IY1-Ov-mqa"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="b3p-iK-gOa" secondAttribute="bottom" id="Jao-Mu-lKI"/>
                             <constraint firstItem="vnt-7W-XjX" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" id="LKk-Jn-5Sl"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="EPw-F5-02E" secondAttribute="bottom" id="LS9-XZ-N25"/>
@@ -119,6 +141,7 @@
                     </view>
                     <connections>
                         <outlet property="calendar" destination="tUD-XX-8aJ" id="9Az-NQ-3eK"/>
+                        <outlet property="createLogButton" destination="Y4Y-Mr-yWF" id="GU2-2g-Z2W"/>
                         <outlet property="dateLabel" destination="PPs-4P-fFy" id="NQc-hh-iMt"/>
                         <outlet property="tableView" destination="PSf-no-2x5" id="TlG-hK-zOh"/>
                     </connections>
@@ -127,13 +150,46 @@
             </objects>
             <point key="canvasLocation" x="44.927536231884062" y="65.625"/>
         </scene>
+        <!--Root View Controller-->
+        <scene sceneID="9dM-yz-NnP">
+            <objects>
+                <tableViewController id="XyV-Qm-Y5v" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="CZ5-mF-249">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="3XW-Yd-mvh">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3XW-Yd-mvh" id="nTP-hy-uUx">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="XyV-Qm-Y5v" id="mUv-K7-ixG"/>
+                            <outlet property="delegate" destination="XyV-Qm-Y5v" id="yn3-Op-Ppr"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Root View Controller" id="a5c-3T-ak2"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="GEb-wt-mDp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="884" y="66"/>
+        </scene>
     </scenes>
     <resources>
+        <image name="square.and.pencil" catalog="system" width="128" height="115"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
-        <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemCyanColor">
+            <color red="0.19607843137254902" green="0.67843137254901964" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/HousekeepingBook/HousekeepingBook/ViewController.swift
+++ b/HousekeepingBook/HousekeepingBook/ViewController.swift
@@ -11,20 +11,21 @@ import FSCalendar
 class ViewController: UIViewController,FSCalendarDataSource,FSCalendarDelegate,UITableViewDataSource,UITableViewDelegate {
 
 //** IBOutlet
-    @IBOutlet weak var calendar: FSCalendar!
-    @IBOutlet weak var dateLabel: UILabel!
-    @IBOutlet weak var tableView: UITableView!
-
+    @IBOutlet private weak var calendar: FSCalendar!
+    @IBOutlet private weak var dateLabel: UILabel!
+    @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private weak var createLogButton: UIButton!
+    
 //** LifeCycle
 
     override func viewDidLoad() {
-        initDateLabel()
         super.viewDidLoad()
+        initDateLabel()
         
         // Do any additional setup after loading the view.
     }
 
-//** Propatiy
+//** Propatiy 後々配列をボタンで作成したものに変更する
     var list = ["月曜","火曜","水曜"]
     let df = DateFormatter()
     

--- a/HousekeepingBook/HousekeepingBook/ViewController.swift
+++ b/HousekeepingBook/HousekeepingBook/ViewController.swift
@@ -18,7 +18,9 @@ class ViewController: UIViewController,FSCalendarDataSource,FSCalendarDelegate,U
 //** LifeCycle
 
     override func viewDidLoad() {
+        initDateLabel()
         super.viewDidLoad()
+        
         // Do any additional setup after loading the view.
     }
 
@@ -43,5 +45,15 @@ class ViewController: UIViewController,FSCalendarDataSource,FSCalendarDelegate,U
     }
 
 
+}
+
+//** MARK ** private Extension
+extension ViewController {
+    func initDateLabel() {
+        if dateLabel.text == "" {
+        df.dateFormat = "yyyy/MM/dd"
+        dateLabel.text = df.string(from: Date())
+        }
+    }
 }
 


### PR DESCRIPTION
## 説明
- 初回画面表示の際は、当日が表示されるよう設定
- ボタンを角丸に設定
- 遷移先の処理については未実装

## 参考資料
https://tech.amefure.com/swift-uikit-fscalender


## 気をつけること

## テスト環境
- [ ] 各人ステージング
- [ ] ステージング
- [ ] 本番

### 端末情報
- 端末種類: 
- iOSバージョン:
- ペアでテストしたアプリのバージョンorコミット番号:

## テスト項目(挙動などのチェック)
- [ ] 

## スクリーンショット
|  変更前  |  変更後  |
| ---- | ---- |
|  url  |  url  |